### PR TITLE
Feat: Add a framerate dropdown with common framerates

### DIFF
--- a/src/XJadeo Video Sync.control.js
+++ b/src/XJadeo Video Sync.control.js
@@ -185,7 +185,6 @@ function init() {
    println("XJadeo Video Sync initialized!");
 }
 
-// Modify the flush function
 function flush() {
    updateOnTop(onTopSetting.get());
    updateTextDisplaySettings(timeDisplayModeSetting.get());
@@ -202,8 +201,6 @@ function flush() {
    updateFrameOffset(Math.floor(offsetSeconds * frameRate));
    updateFrame(Math.floor(pos.get() * frameRate));
    updateLoop(loopSetting.get() === "On");
-
-   // Other flush actions as needed
 }
 
 function exit() {


### PR DESCRIPTION
Hey, I've been noodling around with your extension and I've added a dropdown so you don't have to always type the framerate your video is in. I've put the most common framerates in there, and a "Custom" option that make a setting appear to type in any other framerate you might wanna use.